### PR TITLE
fix: update project branch if default branch was renamed

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -131,7 +131,17 @@ def run():
                 else:
                     app_print(snyk_repo.org_name,
                               snyk_repo.full_name,
-                              "Branch was just renamed, leaving as-is")
+                              "Default branch was renamed, updating project branch")
+                    updated_projects = snyk_repo.update_branch(
+                    gh_repo_status.repo_default_branch,
+                    common.ARGS.dry_run)
+                    for project in updated_projects:
+                        if not common.ARGS.dry_run:
+                            app_print(snyk_repo.org_name,
+                                    snyk_repo.full_name,
+                                    f"Monitored branch set to " \
+                                    f"{gh_repo_status.repo_default_branch} " \
+                                    f"for: {project['manifest']}")
             else: #find deltas
                 app_print(snyk_repo.org_name,
                           snyk_repo.full_name,

--- a/app/app.py
+++ b/app/app.py
@@ -9,7 +9,6 @@ import common
 from app.models import ImportStatus
 from app.gh_repo import (
     get_gh_repo_status,
-    is_default_branch_renamed,
     is_gh_repo_truncated,
     get_git_tree_from_api
 )
@@ -97,47 +96,12 @@ def run():
                           snyk_repo.full_name,
                           f"Default branch name changed from {snyk_repo.branch}" \
                           f" -> {gh_repo_status.repo_default_branch}")
-                app_print(snyk_repo.org_name,
-                          snyk_repo.full_name,
-                          "Checking if existing default branch was just renamed?")
-                try:
-                    if snyk_repo.origin == "github":
-                        is_default_renamed = is_default_branch_renamed(
-                            snyk_repo, gh_repo_status.repo_default_branch,
-                            common.GITHUB_TOKEN)
-                    elif snyk_repo.origin == "github-enterprise":
-                        is_default_renamed = is_default_branch_renamed(
-                            snyk_repo, gh_repo_status.repo_default_branch,
-                            common.GITHUB_ENTERPRISE_TOKEN,
-                            True)
-
-                except RuntimeError as err:
-                    raise RuntimeError("Failed to query GitHub repository!") from err
-
-                if not is_default_renamed:
-                    app_print(snyk_repo.org_name,
-                              snyk_repo.full_name,
-                              "It's a different branch, update snyk projects...")
-                    updated_projects = snyk_repo.update_branch(
-                        gh_repo_status.repo_default_branch,
-                        common.ARGS.dry_run)
-                    for project in updated_projects:
-                        if not common.ARGS.dry_run:
-                            app_print(snyk_repo.org_name,
-                                      snyk_repo.full_name,
-                                      f"Monitored branch set to " \
-                                      f"{gh_repo_status.repo_default_branch} " \
-                                      f"for: {project['manifest']}")
-                else:
-                    app_print(snyk_repo.org_name,
-                              snyk_repo.full_name,
-                              "Default branch was renamed, updating project branch")
-                    updated_projects = snyk_repo.update_branch(
+                updated_projects = snyk_repo.update_branch(
                     gh_repo_status.repo_default_branch,
                     common.ARGS.dry_run)
-                    for project in updated_projects:
-                        if not common.ARGS.dry_run:
-                            app_print(snyk_repo.org_name,
+                for project in updated_projects:
+                    if not common.ARGS.dry_run:
+                        app_print(snyk_repo.org_name,
                                     snyk_repo.full_name,
                                     f"Monitored branch set to " \
                                     f"{gh_repo_status.repo_default_branch} " \

--- a/app/gh_repo.py
+++ b/app/gh_repo.py
@@ -255,34 +255,3 @@ def get_gh_repo_status(snyk_gh_repo):
             repo_default_branch
         )
     return repo_status
-
-def is_default_branch_renamed(snyk_gh_repo, new_branch, github_token, github_enterprise=False):
-    """detect if default branch has been renamed"""
-    is_renamed = False
-    headers = {"Authorization": "Bearer %s"}
-    headers["Authorization"] = headers["Authorization"] % (github_token)
-    if not github_enterprise:
-        request_url = f"https://api.github.com/repos/{snyk_gh_repo.full_name}" \
-            f"/branches/{snyk_gh_repo.branch}"
-        #print("requestURL: " + request_url)
-    else:
-        request_url = f"https://{common.GITHUB_ENTERPRISE_HOST}" \
-        f"/api/v3/repos/{snyk_gh_repo.full_name}/branches/{snyk_gh_repo.branch}"
-    try:
-        response = requests.get(url=request_url, allow_redirects=False, headers=headers)
-
-        if response.status_code in (301, 302):
-            print('redirect response url: ' + response.headers["Location"])
-            if str(response.headers["Location"]).endswith(f"/{new_branch}"):
-                # print('the redirect is pointing to the new branch')
-                is_renamed = True
-            # else:
-            #    print('the redirect is pointing to a different branch')
-        else:
-            is_renamed = False
-    except requests.exceptions.RequestException as err:
-        print(f"exception trying to determine renamed status: {err.response}")
-        #log this to file
-        is_renamed = True
-
-    return is_renamed


### PR DESCRIPTION
If we don't do this everything seems to work fine, but Snyk is not able to open PRs, at least manually, returning `Could not get SHA for branch` errors.

We opted to do it unconditionally and copying the same code that is used on the previous condition, but maybe it would be better to delete the part that checks if the default branch was "just renamed" and always update the branch on the project when branches names differ.

Anyway, we've tested this and it seems to work OK for our use case.

Fixes #64

By the way, this won't work till https://github.com/snyk-tech-services/snyk-scm-refresh/pull/94 is also merged.