### PR TITLE
[WIP] feat: add option to clean archived repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,18 +21,19 @@ usage: snyk_scm_refresh.py [-h] [--org-id ORG_ID] [--repo-name REPO_NAME] [--sca
        [--container {on,off}] [--iac {on,off}] [--code {on,off}] [--dry-run] [--debug]
 
 optional arguments:
-  -h, --help            show this help message and exit
-  --org-id ORG_ID       The Snyk Organisation Id found in Organization > Settings. 
-                        If omitted, process all orgs the Snyk user has access to.
+  -h, --help                show this help message and exit
+  --org-id ORG_ID           The Snyk Organisation Id found in Organization > Settings. 
+                            If omitted, process all orgs the Snyk user has access to.
   --repo-name REPO_NAME
-                        The full name of the repo to process (e.g. githubuser/githubrepo). 
-                        If omitted, process all repos in the Snyk org.
-  --sca {on,off}        scan for SCA manifests (on by default)
-  --container {on,off}  scan for container projects, e.g. Dockerfile (on by default)
-  --iac {on,off}        scan for IAC manifests (experimental, off by default)
-  --code {on,off}       create code analysis if not present (experimental, off by default)
-  --dry-run             Simulate processing of the script without making changes to Snyk
-  --debug               Write detailed debug data to snyk_scm_refresh.log for troubleshooting
+                            The full name of the repo to process (e.g. githubuser/githubrepo). 
+                            If omitted, process all repos in the Snyk org.
+  --sca {on,off}            scan for SCA manifests (on by default)
+  --container {on,off}      scan for container projects, e.g. Dockerfile (on by default)
+  --iac {on,off}            scan for IAC manifests (experimental, off by default)
+  --code {on,off}           create code analysis if not present (experimental, off by default)
+  --clean-archived {on,off} Remove all manifests from archived repos (off by default)
+  --dry-run                 Simulate processing of the script without making changes to Snyk
+  --debug                   Write detailed debug data to snyk_scm_refresh.log for troubleshooting
 ```
 
 ### Sync with defaults

--- a/app/app.py
+++ b/app/app.py
@@ -79,6 +79,10 @@ def run():
 
         elif gh_repo_status["response_code"] == 200: # project exists and has not been renamed
             # snyk has the wrong branch, re-import
+            if gh_repo_status["archived"] == True:
+                app_print(snyk_repo.org_name,
+                          snyk_repo.full_name,
+                          f"Repository is archieved")
             if gh_repo_status["repo_default_branch"] != snyk_repo.branch:
                 app_print(snyk_repo.org_name,
                           snyk_repo.full_name,

--- a/app/app.py
+++ b/app/app.py
@@ -77,25 +77,6 @@ def run():
         if gh_repo_status.response_code == 404: # project no longer exists
             log_potential_delete(snyk_repo.org_name, snyk_repo.full_name)
 
-<<<<<<< HEAD
-        elif gh_repo_status["response_code"] == 200: # project exists and has not been renamed
-            if gh_repo_status["archived"] == True and common.ARGS.clean_archived: # repo is archived and clean-archived flag is set
-                app_print(snyk_repo.org_name,
-                  snyk_repo.full_name,
-                  f"Repo is archived")
-                deleted_projects = snyk_repo.delete_manifests(common.ARGS.dry_run)
-                for project in deleted_projects:
-                    if not common.ARGS.dry_run:
-                        app_print(snyk_repo.org_name,
-                                    snyk_repo.full_name,
-                                    f"Deleted manifest: {project['manifest']}")
-                    else:
-                        app_print(snyk_repo.org_name,
-                                    snyk_repo.full_name,
-                                    f"Would delete manifest: {project['manifest']}")
-            # snyk has the wrong branch, re-import
-            elif gh_repo_status["repo_default_branch"] != snyk_repo.branch:
-=======
         elif gh_repo_status.response_code == 200: # project exists and has not been renamed
             # if --audit-large-repos is on
             if common.ARGS.audit_large_repos:
@@ -110,9 +91,22 @@ def run():
                 )
                 # move to next repo without processing the rest of the code
                 continue
+            if gh_repo_status.archived == True and common.ARGS.clean_archived: # repo is archived and clean-archived flag is set
+                app_print(snyk_repo.org_name,
+                  snyk_repo.full_name,
+                  f"Repo is archived")
+                deleted_projects = snyk_repo.delete_manifests(common.ARGS.dry_run)
+                for project in deleted_projects:
+                    if not common.ARGS.dry_run:
+                        app_print(snyk_repo.org_name,
+                                    snyk_repo.full_name,
+                                    f"Deleted manifest: {project['manifest']}")
+                    else:
+                        app_print(snyk_repo.org_name,
+                                    snyk_repo.full_name,
+                                    f"Would delete manifest: {project['manifest']}")
             # snyk has the wrong branch, re-import
-            if gh_repo_status.repo_default_branch != snyk_repo.branch:
->>>>>>> parent/develop
+            elif gh_repo_status.repo_default_branch != snyk_repo.branch:
                 app_print(snyk_repo.org_name,
                           snyk_repo.full_name,
                           f"Default branch name changed from {snyk_repo.branch}" \

--- a/app/app.py
+++ b/app/app.py
@@ -78,12 +78,22 @@ def run():
             log_potential_delete(snyk_repo.org_name, snyk_repo.full_name)
 
         elif gh_repo_status["response_code"] == 200: # project exists and has not been renamed
-            # snyk has the wrong branch, re-import
-            if gh_repo_status["archived"] == True:
+            if gh_repo_status["archived"] == True and common.ARGS.clean_archived: # repo is archived and clean-archived flag is set
                 app_print(snyk_repo.org_name,
-                          snyk_repo.full_name,
-                          f"Repository is archieved")
-            if gh_repo_status["repo_default_branch"] != snyk_repo.branch:
+                  snyk_repo.full_name,
+                  f"Repo is archived")
+                deleted_projects = snyk_repo.delete_manifests(common.ARGS.dry_run)
+                for project in deleted_projects:
+                    if not common.ARGS.dry_run:
+                        app_print(snyk_repo.org_name,
+                                    snyk_repo.full_name,
+                                    f"Deleted manifest: {project['manifest']}")
+                    else:
+                        app_print(snyk_repo.org_name,
+                                    snyk_repo.full_name,
+                                    f"Would delete manifest: {project['manifest']}")
+            # snyk has the wrong branch, re-import
+            elif gh_repo_status["repo_default_branch"] != snyk_repo.branch:
                 app_print(snyk_repo.org_name,
                           snyk_repo.full_name,
                           f"Default branch name changed from {snyk_repo.branch}" \

--- a/app/gh_repo.py
+++ b/app/gh_repo.py
@@ -183,6 +183,7 @@ def get_gh_repo_status(snyk_gh_repo):
     response_message = ""
     response_status_code = ""
     repo_default_branch = ""
+    archived = ""
 
     # logging.debug(f"snyk_gh_repo origin: {snyk_gh_repo.origin}")
 

--- a/app/gh_repo.py
+++ b/app/gh_repo.py
@@ -79,6 +79,7 @@ def get_gh_repo_status(snyk_gh_repo, github_token, github_enterprise=False):
         if response.status_code == 200:
             response_message = "Match"
             repo_default_branch = response.json()['default_branch']
+            archived = response.json()['archived']
 
         elif response.status_code == 404:
             response_message = "Not Found"
@@ -107,7 +108,8 @@ def get_gh_repo_status(snyk_gh_repo, github_token, github_enterprise=False):
             "snyk_org_id": snyk_gh_repo["org_id"],
             "repo_owner": repo_owner,
             "repo_full_name": f"{repo_owner}/{repo_name}",
-            "repo_default_branch": repo_default_branch
+            "repo_default_branch": repo_default_branch,
+            "archived": archived
         }
 
     except requests.exceptions.RequestException as err:

--- a/app/gh_repo.py
+++ b/app/gh_repo.py
@@ -232,26 +232,12 @@ def get_gh_repo_status(snyk_gh_repo):
                 repo_new_full_name = follow_response.json()["full_name"]
                 repo_owner = repo_new_full_name.split("/")[0]
                 repo_name = repo_new_full_name.split("/")[1]
+                archived = response.json()['archived']
             else:
                 repo_owner = ""
                 repo_name = ""
 
-<<<<<<< HEAD
-            response_message = "Moved to %s" % repo_name
-
-        repo_status = {
-            "response_code": response.status_code,
-            "response_message": response_message,
-            "repo_name": repo_name,
-            "snyk_org_id": snyk_gh_repo["org_id"],
-            "repo_owner": repo_owner,
-            "repo_full_name": f"{repo_owner}/{repo_name}",
-            "repo_default_branch": repo_default_branch,
-            "archived": archived
-        }
-=======
             response_message = f"Moved to {repo_name}"
->>>>>>> parent/develop
 
     except requests.exceptions.RequestException as err:
         # make sure it gets logged in log file when in debug mode
@@ -268,7 +254,8 @@ def get_gh_repo_status(snyk_gh_repo):
             snyk_gh_repo["org_id"],
             repo_owner,
             f"{repo_owner}/{repo_name}",
-            repo_default_branch
+            repo_default_branch,
+            archived
         )
     return repo_status
 

--- a/app/models.py
+++ b/app/models.py
@@ -39,4 +39,5 @@ class GithubRepoStatus:
     repo_owner: str
     repo_full_name: str
     repo_default_branch: str
+    archived: str
     

--- a/app/snyk_repo.py
+++ b/app/snyk_repo.py
@@ -101,6 +101,24 @@ class SnykRepo():
                             f" in org {snyk_project['org_id']}")
         return result
 
+    def delete_manifests(self, dry_run):
+        """ delete all snyk projects corresponding to a repo """
+        result = []
+        gh_repo_manifests = get_repo_manifests(self.full_name, self.origin, True)
+        for snyk_project in self.snyk_projects:
+            # delete project, append on success
+            if not dry_run:
+                try:
+                    app.utils.snyk_helper.delete_snyk_project(snyk_project["id"],
+                                                                snyk_project["org_id"])
+                    result.append(snyk_project)
+                except snyk.errors.SnykNotFoundError:
+                    print(f"    - Project {snyk_project['id']} not found" \
+                        f" in org {snyk_project['org_id']}")
+            else:
+                result.append(snyk_project)
+        return result
+
     def update_branch(self, new_branch_name, dry_run):
         """ update the branch for all snyk projects for this repo """
         result = []

--- a/common.py
+++ b/common.py
@@ -129,6 +129,13 @@ def parse_command_line_args():
         required=False,
         action="store_true",
     )
+    parser.add_argument(
+        "--clean-archived",
+        help="wheter to delete manifests of archived respos",
+        required=False,
+        default=False,
+        choices=['on', 'off']
+    )
 
     return parser.parse_args()
 
@@ -145,3 +152,4 @@ PROJECT_TYPE_ENABLED_SCA = toggle_to_bool(ARGS.sca)
 PROJECT_TYPE_ENABLED_CONTAINER = toggle_to_bool(ARGS.container)
 PROJECT_TYPE_ENABLED_IAC = toggle_to_bool(ARGS.iac)
 PROJECT_TYPE_ENABLED_CODE = toggle_to_bool(ARGS.code)
+CLEAN_ARCHIVED = toggle_to_bool(ARGS.clean_archived)


### PR DESCRIPTION
We added an option (`--clean-archived`), off by default, that makes `snyk-scm-refresh` clean all manifests of a project if the corresponding repository has been archived.

We've tested this on our tenant and it works OK.

The only problem is that we don't know how to delete the `target`, after all its projects has been deleted.

Using the web UI we've seen that, when using the button, this is done by issuing a `DELETE` to:
* https://app.snyk.io/org/{{org-name}}/targets/{{target-UUID}}

But we cannot really find how to do that using the API. Any help/ideas @scotte-snyk ?

If merged, this fixes #97 