### PR TITLE
chore: bump `snyk-labs/pysnyk`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pysnyk==0.6.1
+pysnyk==0.9.3
 PyGithub==1.47
-requests==2.25.0
+requests==2.28.0
 urllib3==1.26.5


### PR DESCRIPTION
Bumps the `snyk-labs/pysnyk` from `0.6.1` to `0.9.3` in an effort to fix #102

It's not 100% clear on what changed to cause this error, but I was able to replicate the issue consistently, and updating `pysnyk` to the latest version seems to do the trick. The requests library was also updated to satisfy constraints, but updating this dependency alone did not solve the issue