### PR TITLE
chore: handle 403 errors from github

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -170,6 +170,10 @@ def run():
                           snyk_repo.full_name,
                           "Would import repo (all targets) under new name")
 
+        # 403 could indicate rate limit apparently so it's better to throw
+        # and let the caller retry the process at some later phase :shrug: 
+        elif gh_repo_status.response_code == 403:
+            raise RuntimeError("Github returned 403, probably rate limit")
         else:
             app_print(snyk_repo.org_name,
                       snyk_repo.full_name,


### PR DESCRIPTION
Right now the code swallow those 403 errors and not do anything with them. I noticed they happened after a a lot of successful requests so I am suspecting rate limits (also Google says this what will happen, but I didn't see any official docs about that).
We might also don't want to swallow any 4** errors and always throw 🤷 