### PR TITLE
fix: Bumping Pysnyk to version 0.9.9 to fix branch information

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pysnyk==0.9.8
+pysnyk==0.9.9
 PyGithub==1.47
 requests==2.28.0
 urllib3==1.26.5


### PR DESCRIPTION
Updating Pysnyk to version 0.9.9 to add branch information